### PR TITLE
Add a gitsha-release command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ release: check-api-token check-app deps-vendor-cli
 		--release-notes $(release_notes) \
 		--ensure-channel
 
+gitsha-release:
+	@$(MAKE) release \
+		channel=refs/heads/$(shell git rev-parse --abbrev-ref HEAD) \
+		version=$(shell git rev-parse HEAD | head -c7)$(shell git diff --no-ext-diff --quiet --exit-code || echo -n "-dirty")


### PR DESCRIPTION
Add a `make gitsha-release` command to match the behavior of our github
action.

Rationale
------

Right now, our recommended workflow is to use GitHub actions to create
new releases, and that works great. It has the benefit of giving us:

- very easy onboarding process, no new tools or CLIs to install for new developers
- auto-generated versions based on SHAs
- auto-detected channel names based on Git Branch or Ref
- auto-generated release notes based on ${GITHUB_SHA} and ${GITHUB_ACTOR}

The only downside is that pushing to github and waiting for an action to fire is pretty slow. This lets folks follow the same patterns for their local dev, using Make commands instead:

- Channel name comes from whatever Git branch you're currently on
- Version label comes from git sha, adding `-dirty` if there are uncomitted changes

This means you can `make gitsha-release`, and get a new version available for download in kotsadm in 2-5 seconds instead of 20-50 seconds.

Next steps
--------
Depending on how this goes, we could also consider making this the *default* release command, instead of defaulting to the Unstable channel
and the fake semver-ish thing we've been using.