### PR TITLE
Improving makefile to support other branches, and tagging on Beta channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ list-releases: check-api-token check-app deps-vendor-cli
 
 .PHONY: release
 release: check-api-token check-app deps-vendor-cli
-	@if [[ ${channel) == -x ../deps/replicated ]]; then exit 0; else \
 	deps/replicated release create \
 		--app $(app_slug) \
 		--yaml-dir manifests \

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,11 @@ version := ${GITHUB_TAG_NAME}
 endif
 
 .PHONY: deps-vendor-cli
-	$(eval dist := $(shell echo `uname` | tr '[:upper:]' '[:lower:]'))
-	$(eval cli_version := $(shell [[ -x deps/replicated ]] && deps/replicated version | grep version | head -n1 | cut -d: -f2 | tr -d , ))
+deps-vendor-cli: dist = $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
+deps-vendor-cli: cli_version = ""
+deps-vendor-cli: cli_version = $(shell [[ -x deps/replicated ]] && deps/replicated version | grep version | head -n1 | cut -d: -f2 | tr -d , )
 
+deps-vendor-cli: 
 	@if [[ -n "$(cli_version)" ]]; then \
 	  echo "CLI version $(cli_version) already downloaded, to download a newer version, run 'make upgrade-cli'"; \
 	  exit 0; \

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ list-releases: check-api-token check-app deps-vendor-cli
 	deps/replicated release ls --app $(app_slug)
 
 .PHONY: release
-release: check-api-token check-app deps-vendor-cli
+release: check-api-token check-app deps-vendor-cli lint
 	deps/replicated release create \
 		--app $(app_slug) \
 		--yaml-dir manifests \

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ app_slug := "${REPLICATED_APP}"
 release_notes := "CLI release by ${shell git log -1 --pretty=format:'%ae'} on $(shell date)"
 
 # If tag is set and we're using github_actions, that takes precedence and we release on the beta channel. 
-# Otherwise, get the branch, ensure the first char is uppercase, and use to build version. 
+# Otherwise, get the branch use to build version and release on that channel
 ifeq ($(origin GITHUB_TAG_NAME),undefined)
 ifeq ($(origin ${GITHUB_BRANCH_NAME}),undefined)
-channel := $(shell ch=$$(git rev-parse --abbrev-ref HEAD);echo $$(tr '[:lower:]' '[:upper:]' <<< $${ch:0:1})$${ch:1})
+channel := $(shell git rev-parse --abbrev-ref HEAD)
 else 
-channel := $(shell ch=$$(GITHUB_BRANCH_NAME);echo $$(tr '[:lower:]' '[:upper:]' <<< $${ch:0:1})$${ch:1})
+channel := ${GITHUB_BRANCH_NAME}
 endif 
 # Translate "Master" to "Unstable", if on that branch
-ifeq ($(channel), Master)
+ifeq ($(channel), master)
 channel := Unstable
 endif 
 version := $(channel)-$(shell git rev-parse HEAD | head -c7)$(shell git diff --no-ext-diff --quiet --exit-code || echo "-dirty")


### PR DESCRIPTION
* Improved username in release notes (gets author in both github and local env)
* If on xyz branch, we release on Xyz channel with a hash and an optional "dirty" flag
* The exception to the above: When on "master" branch, we release to "Stable" channel.
* If a tag comes in, we release on Beta channel with a version matching the tag (We want all these situations to be through CI, so this isn't supported locally).