### PR TITLE
Fix branchname bug. Generate release notes that provide origin details.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,4 @@ jobs:
         REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
         GITHUB_BRANCH_NAME: ${{ steps.get_branch.outputs.branch }}
         GITHUB_TAG_NAME: ${{ steps.get_tag.outputs.tag }}
-        GITHUB_REF: $({ GITHUB_REF )}
-        GITHUB_ACTOR: ${( GITHUB_ACTOR })
-        GITHUB_SHA: ${( GITHUB_SHA )}
-        GITHUB_REPOSITORY: ${( GITHUB_REPOSITORY )}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
         GITHUB_BRANCH_NAME: ${{ steps.get_branch.outputs.branch }}
         GITHUB_TAG_NAME: ${{ steps.get_tag.outputs.tag }}
-        GITHUB_REF: ${GITHUB_REF}
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
-        GITHUB_SHA: ${GITHUB_SHA}
-        GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}
+        GITHUB_REF: $({ GITHUB_REF )}
+        GITHUB_ACTOR: ${( GITHUB_ACTOR })
+        GITHUB_SHA: ${( GITHUB_SHA )}
+        GITHUB_REPOSITORY: ${( GITHUB_REPOSITORY )}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,3 +26,7 @@ jobs:
         REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
         GITHUB_BRANCH_NAME: ${{ steps.get_branch.outputs.branch }}
         GITHUB_TAG_NAME: ${{ steps.get_tag.outputs.tag }}
+        GITHUB_REF: ${GITHUB_REF}
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+        GITHUB_SHA: ${GITHUB_SHA}
+        GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash -o pipefail
 app_slug := "${REPLICATED_APP}"
 
 # Generate release notes that provide origin details. 
-ifeq ($(origin $(GITHUB_REF)), undefined)
+ifeq ($(origin ${GITHUB_REF}), undefined)
 release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git log -1 --pretty=format:'%ae'}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD)]"
 else 
 release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ app_slug := "${REPLICATED_APP}"
 ifeq ($(origin GITHUB_ACTIONS), undefined)
 release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git log -1 --pretty=format:'%ae'}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD)]"
 else 
-release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
+release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [$(shell echo $${GITHUB_SHA::7})](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
 endif 
 
 # If tag is set and we're using github_actions, that takes precedence and we release on the beta channel. 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ lint: check-api-token check-app deps-vendor-cli
 
 .PHONY: check-api-token
 check-api-token:
+	@echo ${GITHUB_ACTIONS}
+	@echo ${GITHUB_REF}
+	@echo ${GITHUB_SHA}
+	@echo ${GITHUB_ACTOR}
+	@echo ${GITHUB_REPOSITORY}
 	@if [ -z "${REPLICATED_API_TOKEN}" ]; then echo "Missing REPLICATED_API_TOKEN"; exit 1; fi
 
 .PHONY: check-app

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 SHELL := /bin/bash -o pipefail
 
 app_slug := "${REPLICATED_APP}"
-release_notes := "CLI release by ${shell git log -1 --pretty=format:'%ae'} on $(shell date)"
+
+# Generate release notes that provide origin details. 
+ifeq ($(origin $(GITHUB_ACTIONS)), undefined)
+release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git log -1 --pretty=format:'%ae'}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD)]"
+else 
+release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
+endif 
 
 # If tag is set and we're using github_actions, that takes precedence and we release on the beta channel. 
 # Otherwise, get the branch use to build version and release on that channel
-ifeq ($(origin GITHUB_TAG_NAME),undefined)
+ifeq ($(origin ${GITHUB_TAG_NAME}),undefined)
 ifeq ($(origin ${GITHUB_BRANCH_NAME}),undefined)
 channel := $(shell git rev-parse --abbrev-ref HEAD)
 else 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash -o pipefail
 app_slug := "${REPLICATED_APP}"
 
 # Generate release notes that provide origin details. 
-ifeq ($(origin $(GITHUB_ACTIONS)), undefined)
+ifeq ($(origin $(GITHUB_REF)), undefined)
 release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git log -1 --pretty=format:'%ae'}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD)]"
 else 
 release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,6 @@ lint: check-api-token check-app deps-vendor-cli
 
 .PHONY: check-api-token
 check-api-token:
-	@echo ${GITHUB_ACTIONS}
-	@echo ${GITHUB_REF}
-	@echo ${GITHUB_SHA}
-	@echo ${GITHUB_ACTOR}
-	@echo ${GITHUB_REPOSITORY}
 	@if [ -z "${REPLICATED_API_TOKEN}" ]; then echo "Missing REPLICATED_API_TOKEN"; exit 1; fi
 
 .PHONY: check-app

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash -o pipefail
 app_slug := "${REPLICATED_APP}"
 
 # Generate release notes that provide origin details. 
-ifeq ($(origin ${GITHUB_REF}), undefined)
+ifeq ($(origin GITHUB_ACTIONS), undefined)
 release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git log -1 --pretty=format:'%ae'}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD)]"
 else 
 release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
@@ -11,8 +11,8 @@ endif
 
 # If tag is set and we're using github_actions, that takes precedence and we release on the beta channel. 
 # Otherwise, get the branch use to build version and release on that channel
-ifeq ($(origin ${GITHUB_TAG_NAME}),undefined)
-ifeq ($(origin ${GITHUB_BRANCH_NAME}),undefined)
+ifeq ($(origin GITHUB_TAG_NAME),undefined)
+ifeq ($(origin GITHUB_BRANCH_NAME),undefined)
 channel := $(shell git rev-parse --abbrev-ref HEAD)
 else 
 channel := ${GITHUB_BRANCH_NAME}


### PR DESCRIPTION
Through the CLI, it will look like: 
> CLI release of refs/heads/austin triggered by icarusdignata@gmail.com: replicated-starter-kots [SHA: 4d8259cf614f5b69b796a85cad43c85a0f1f0212]

Through github actions (where we know a link exists), it will look like: 
> GitHub Action release of refs/heads/austin triggered by austinchambers: [11e192f](https://github.com/replicatedhq/***/commit/11e192fe38b45a002a2ba91c31c45c45597daa66)

