### PR TITLE
Fixing issues with release notes/Makefile.advanced and branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,17 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 0
+    - name: Get tag name, if specified
+      run: if grep -q "/tags/" <<< "${GITHUB_REF}"; then echo ::set-output name=tag::${GITHUB_REF:10}; fi
+      id: get_tag
+    - name: Get branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: get_branch
     - name: Create a release on Channel associated with the branch
-      run: |
-        make release channel=${GITHUB_REF#refs/heads/} release_notes="'GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})'"
+      run: make release
       env:
         REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
         REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+        GITHUB_BRANCH_NAME: ${{ steps.get_branch.outputs.branch }}
+        GITHUB_TAG_NAME: ${{ steps.get_tag.outputs.tag }}
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,23 @@
 SHELL := /bin/bash -o pipefail
 
 app_slug := "${REPLICATED_APP}"
-release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git config --global user.name}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD | head -c 7)]"
-git_branch := $(shell git rev-parse --abbrev-ref HEAD)
 
-ifeq ($(git_branch), master)
-channel := Unstable
+# Generate channel and release notes. We need to do this differently for github actions vs. command line because of how git works differently in GH actions. 
+ifeq ($(origin GITHUB_ACTIONS), undefined)
+release_notes := "CLI release of $(shell git symbolic-ref HEAD) triggered by ${shell git config --global user.name}: $(shell basename $$(git remote get-url origin) .git) [SHA: $(shell git rev-parse HEAD)]"
+channel := $(shell git rev-parse --abbrev-ref HEAD)
 else
-channel := $(git_branch)
+release_notes := "GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [$(shell echo $${GITHUB_SHA::7})](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
+channel := ${GITHUB_BRANCH_NAME}
+endif
+
+# If we're on the master channel, translate that to the "Unstable" channel
+ifeq ($(channel), master)
+channel := Unstable
 endif
 
 # version based on branch/channel
 version := $(channel)-$(shell git rev-parse HEAD | head -c7)$(shell git diff --no-ext-diff --quiet --exit-code || echo "-dirty")
-
-
 
 .PHONY: deps-vendor-cli
 deps-vendor-cli: upstream_version = $(shell  curl --silent --location --fail --output /dev/null --write-out %{url_effective} https://github.com/replicatedhq/replicated/releases/latest | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+$$')


### PR DESCRIPTION
There were a couple issues caused with the split to the makefiles: 
* The branch returned by github actions was always incorrect, causing all releases on 'master' branch to go to the 'master' channel (instead of the "Unstable" channel). I believe this also caused a few "Ref" errors in the GH actions. 
* The workflow files lost parity with the makefiles. It stopped being possible to change from Makefile to Makefile.advanced since the needed information about tags stopped being available. 

Verified by ensuring a release on the Unstable channel for Snyk, and checking release notes. 