### PR TITLE
Updated version of API

### DIFF
--- a/manifests/preflight.yaml
+++ b/manifests/preflight.yaml
@@ -1,4 +1,4 @@
-apiVersion: troubleshoot.replicated.com/v1beta1
+apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
   name: example-preflight-checks


### PR DESCRIPTION
Updated `apiVersion` to the most current to have parity with the latest docs.
Ran install and verified the preflights still worked as-is.
![Screen Shot 2021-04-16 at 3 49 30 PM](https://user-images.githubusercontent.com/13663801/115077189-a349bb00-9ecb-11eb-9251-4d814267fabc.png)
 