### PR TITLE
Fix for preflights in the starter repo

### DIFF
--- a/manifests/preflight.yaml
+++ b/manifests/preflight.yaml
@@ -59,7 +59,7 @@ spec:
           - fail:
               when: "sum(cpuCapacity) < 2"
               message: The cluster must contain at least 2 cores
-          - fail:
+          - warn:
               when: "sum(cpuCapacity) < 4"
               message: The cluster must contain at least 4 cores
           - pass:


### PR DESCRIPTION
Fixed the preflight logic to warn when the CPU cores are below 4 and above 2.