### PR TITLE
Changing Collector to SupportBundle

### DIFF
--- a/manifests/support-bundle.yaml
+++ b/manifests/support-bundle.yaml
@@ -1,7 +1,7 @@
 apiVersion: troubleshoot.replicated.com/v1beta1
-kind: Collector
+kind: SupportBundle
 metadata:
-  name: collector-sample
+  name: support-sample
 spec:
   collectors:
     - clusterInfo: {}


### PR DESCRIPTION
If `kind` is `Collector`, `Analyzers` won't be picked up.