### PR TITLE
Default support-bundle.yaml maxAge property is invalid

### DIFF
--- a/manifests/support-bundle.yaml
+++ b/manifests/support-bundle.yaml
@@ -12,5 +12,5 @@ spec:
           - component=nginx
         namespace: '{{repl Namespace }}'
         limits:
-          maxAge: 30d
+          maxAge: 720h
           maxLines: 10000


### PR DESCRIPTION
[time.ParseDuration](https://pkg.go.dev/time#ParseDuration) does not recognize days.

Support bundle produces error

```
2021/07/26 16:07:57 Failed to parse time duration 30d
```