### PR TITLE
Update example-ingress.yaml

### DIFF
--- a/manifests/example-ingress.yaml
+++ b/manifests/example-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress
@@ -9,7 +9,9 @@ spec:
   - http:
       paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: example-nginx
-            servicePort: 80
-
+            service:
+              name: example-nginx
+              port: 
+                number: 80


### PR DESCRIPTION
Since kurl is now using 1.23.x for latest, this is broken. Using the non-beta should fix this for the default `latest` spec.