### PR TITLE
Readme: Fix curl manual CLI installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ brew install replicatedhq/replicated/cli
 
 ```shell script
 curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
-           | grep "browser_download_url.*$(uname | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" \
+           | grep "browser_download_url.*$(uname | tr '[:upper:]' '[:lower:]')_all.tar.gz" \
            | cut -d : -f 2,3 \
            | tr -d \" \
            | cat <( echo -n "url") - \


### PR DESCRIPTION
The OS key in the browser download URL for macOS is now darwin_all instead of darwin_amd64.