### PR TITLE
New latest spec with openebs instead of longhorn

### DIFF
--- a/kurl-installer.yaml
+++ b/kurl-installer.yaml
@@ -5,7 +5,7 @@ metadata:
   name: 'myapp'
 spec:
   kubernetes:
-    version: latest
+    version: 1.24.x
   containerd:
     version: latest
   weave:

--- a/kurl-installer.yaml
+++ b/kurl-installer.yaml
@@ -10,10 +10,6 @@ spec:
     version: latest
   weave:
     version: latest
-  minio:
-    version: latest
-  longhorn:
-    version: latest
   registry:
     version: latest
   prometheus:
@@ -22,3 +18,18 @@ spec:
     version: latest
   ekco:
     version: latest
+  minio:
+    version: latest
+
+  # OpenEBS is the default PVC provisioner, and
+  # will work for single node clusters, or for
+  # applications that handle data replication
+  # between nodes themselves (MongoDB, Cassandra,
+  # etc). If your requirements are different than
+  # this, contact us at
+  # https://community.replicated.com.
+  #
+  openebs:
+    version: latest
+    isLocalPVEnabled: true
+    localPVStorageClassName: default

--- a/kurl-installer.yaml
+++ b/kurl-installer.yaml
@@ -21,13 +21,13 @@ spec:
   minio:
     version: latest
 
-  # OpenEBS is the default PVC provisioner, and
+  # OpenEBS is the default PV provisioner, and
   # will work for single node clusters, or for
   # applications that handle data replication
   # between nodes themselves (MongoDB, Cassandra,
   # etc). If your requirements are different than
   # this, contact us at
-  # https://community.replicated.com.
+  # https://community.replicated.com .
   #
   openebs:
     version: latest


### PR DESCRIPTION
Changes recommended kurl installer spec from longhorn to openebs with local pv provisioner.
Updates kuberentes version to 1.24.x from 1.19.x