### PR TITLE
feat: flannel is now default cni from latest spec

### DIFF
--- a/kurl-installer.yaml
+++ b/kurl-installer.yaml
@@ -8,7 +8,7 @@ spec:
     version: 1.26.x
   containerd:
     version: latest
-  weave:
+  flannel:
     version: latest
   registry:
     version: latest


### PR DESCRIPTION
Returns Flannel as the default CNI rather than Weave for the default kURL spec.

https://github.com/replicatedhq/kURL-api/pull/132